### PR TITLE
Fixed some problems on cuda-torch:8.0

### DIFF
--- a/cuda-torch/cuda_v8.0/Dockerfile
+++ b/cuda-torch/cuda_v8.0/Dockerfile
@@ -1,5 +1,5 @@
 # Start with cuDNN base image
-FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
+FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04
 MAINTAINER Kai Arulkumaran <design@kaixhin.com>
 
 # Install git, apt-add-repository and dependencies for iTorch

--- a/cuda-torch/cuda_v8.0/Dockerfile
+++ b/cuda-torch/cuda_v8.0/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y \
   libzmq3-dev \
   python-dev \
   python-pip \
-  python-zmq \
   sudo
 
 # Install Jupyter Notebook for iTorch

--- a/cuda-torch/cuda_v8.0/Dockerfile
+++ b/cuda-torch/cuda_v8.0/Dockerfile
@@ -1,5 +1,5 @@
 # Start with cuDNN base image
-FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu14.04
+FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
 MAINTAINER Kai Arulkumaran <design@kaixhin.com>
 
 # Install git, apt-add-repository and dependencies for iTorch


### PR DESCRIPTION
Hello.

I found some errors on cuda-torch:8.0.

* Current cuda-torch uses Ubuntu 14.04 but Tornado needs 16.04
* APT python-zmp package conflicts with pip
* Torch needs cuDNN 5, but the current version is 6 (this causes runtime-error)